### PR TITLE
fix(ci): disable ko SBOM to avoid GHCR permission error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,5 @@ jobs:
           cd collector && go tool ko build . \
             --platform=linux/amd64,linux/arm64 \
             --bare \
+            --sbom=none \
             --tags "sha-$(git rev-parse --short HEAD),latest"


### PR DESCRIPTION
## Problem

The first `build-and-push` run (#1) failed at the very end with:

```
Error: failed to publish images: error publishing ko://github.com/zmoog/collector/collector:
  writing sbom: POST https://ghcr.io/v2/zmoog/collector/blobs/uploads/: DENIED: permission_denied: write_package
```

The image itself was built and pushed successfully (`sha-7fa0169` + `latest` were tagged). The failure was in ko's default post-push step: attaching an SBOM as a secondary OCI artifact. GHCR denies that second write with `write_package`.

## Fix

Add `--sbom=none` to skip SBOM generation entirely.